### PR TITLE
feat: multiple color cases for highlight line of code

### DIFF
--- a/lib/prism-line-highlight.js
+++ b/lib/prism-line-highlight.js
@@ -1,12 +1,15 @@
-export function extendLineHighlightPlugin (Prism) {
-
-	if (typeof Prism === 'undefined' || typeof document === 'undefined' || !document.querySelector) {
+export function extendLineHighlightPlugin(Prism) {
+	if (
+		typeof Prism === "undefined" ||
+		typeof document === "undefined" ||
+		!document.querySelector
+	) {
 		return;
 	}
 
-	var LINE_NUMBERS_CLASS = 'line-numbers';
-	var LINKABLE_LINE_NUMBERS_CLASS = 'linkable-line-numbers';
-	var NEW_LINE_REGEX = /\n(?!$)/g
+	var LINE_NUMBERS_CLASS = "line-numbers";
+	var LINKABLE_LINE_NUMBERS_CLASS = "linkable-line-numbers";
+	var NEW_LINE_REGEX = /\n(?!$)/g;
 
 	/**
 	 * @param {string} selector
@@ -14,7 +17,9 @@ export function extendLineHighlightPlugin (Prism) {
 	 * @returns {HTMLElement[]}
 	 */
 	function $$(selector, container) {
-		return Array.prototype.slice.call((container || document).querySelectorAll(selector));
+		return Array.prototype.slice.call(
+			(container || document).querySelectorAll(selector)
+		);
 	}
 
 	/**
@@ -43,13 +48,13 @@ export function extendLineHighlightPlugin (Prism) {
 	var isLineHeightRounded = (function () {
 		var res;
 		return function () {
-			if (typeof res === 'undefined') {
-				var d = document.createElement('div');
-				d.style.fontSize = '13px';
-				d.style.lineHeight = '1.5';
-				d.style.padding = '0';
-				d.style.border = '0';
-				d.innerHTML = '&nbsp;<br />&nbsp;';
+			if (typeof res === "undefined") {
+				var d = document.createElement("div");
+				d.style.fontSize = "13px";
+				d.style.lineHeight = "1.5";
+				d.style.padding = "0";
+				d.style.border = "0";
+				d.innerHTML = "&nbsp;<br />&nbsp;";
 				document.body.appendChild(d);
 				// Browsers that round the line-height should have offsetHeight === 38
 				// The others should have 39.
@@ -58,7 +63,7 @@ export function extendLineHighlightPlugin (Prism) {
 			}
 			return res;
 		};
-	}());
+	})();
 
 	/**
 	 * Returns the top offset of the content box of the given parent and the content box of one of its children.
@@ -79,10 +84,12 @@ export function extendLineHighlightPlugin (Prism) {
 			return +px.substr(0, px.length - 2);
 		}
 
-		return child.offsetTop
-			+ pxToNumber(childStyle.borderTopWidth)
-			+ pxToNumber(childStyle.paddingTop)
-			- pxToNumber(parentStyle.paddingTop);
+		return (
+			child.offsetTop +
+			pxToNumber(childStyle.borderTopWidth) +
+			pxToNumber(childStyle.paddingTop) -
+			pxToNumber(parentStyle.paddingTop)
+		);
 	}
 
 	/**
@@ -98,7 +105,7 @@ export function extendLineHighlightPlugin (Prism) {
 			return false;
 		}
 
-		if (pre.hasAttribute('data-line')) {
+		if (pre.hasAttribute("data-line")) {
 			return true;
 		}
 
@@ -126,19 +133,53 @@ export function extendLineHighlightPlugin (Prism) {
 		 * @returns {() => void}
 		 */
 		highlightLines: function highlightLines(pre, lines, classes) {
-			lines = typeof lines === 'string' ? lines : (pre.getAttribute('data-line') || '');
+			lines =
+				typeof lines === "string"
+					? lines
+					: pre.getAttribute("data-line") || "";
 
-			var ranges = lines.replace(/\s+/g, '').split(',').filter(Boolean);
-			var offset = +pre.getAttribute('data-line-offset') || 0;
+			function generateClassByType(type) {
+				switch (type) {
+					case "a":
+						return "add-reading-codeblock-highlight";
+					case "e":
+						return "error-reading-codeblock-highlight";
+					case "c":
+						return "comment-reading-codeblock-highlight";
+					case "g":
+						return "general-reading-codeblock-highlight";
+					default:
+						return "general-reading-codeblock-highlight";
+				}
+			}
+
+			// _result[0] -> line 1,1-3
+			// _result[1] -> type a,e,c,g
+			const [highlightLines, highlighType] = lines
+				.replace(" ", "")
+				.split(",")
+				.reduce(
+					(acc, line) => {
+						const _type = line.split("@")[0] || "g";
+						const _line = line.split("@")[1] || _type;
+						acc[0].push(_line);
+						acc[1].push(_type);
+						return acc;
+					},
+					[[], []]
+				);
+
+			var ranges = lines.replace(/\s+/g, "").split(",").filter(Boolean);
+			var offset = +pre.getAttribute("data-line-offset") || 0;
 
 			var parseMethod = isLineHeightRounded() ? parseInt : parseFloat;
 			var lineHeight = parseMethod(getComputedStyle(pre).lineHeight);
 			var hasLineNumbers = Prism.util.isActive(pre, LINE_NUMBERS_CLASS);
-			var codeElement = pre.querySelector('code');
+			var codeElement = pre.querySelector("code");
 			var parentElement = hasLineNumbers ? pre : codeElement || pre;
 			var mutateActions = /** @type {(() => void)[]} */ ([]);
 			var lineBreakMatch = codeElement.textContent.match(NEW_LINE_REGEX);
-			var numberOfLines = lineBreakMatch? lineBreakMatch.length + 1: 1
+			var numberOfLines = lineBreakMatch ? lineBreakMatch.length + 1 : 1;
 
 			/**
 			 * The top offset between the content box of the <code> element and the content box of the parent element of
@@ -150,72 +191,100 @@ export function extendLineHighlightPlugin (Prism) {
 			 *
 			 * This offset will be 0 if the parent element of the line highlight element is the `<code>` element.
 			 */
-			var codePreOffset = !codeElement || parentElement == codeElement ? 0 : getContentBoxTopOffset(pre, codeElement);
+			var codePreOffset =
+				!codeElement || parentElement == codeElement
+					? 0
+					: getContentBoxTopOffset(pre, codeElement);
+			Array.isArray(highlightLines) &&
+				highlightLines.forEach(function (currentRange) {
+					var range = currentRange.split("-");
 
-			ranges.forEach(function (currentRange) {
-				var range = currentRange.split('-');
+					var start = +range[0];
+					var end = +range[1] || start;
+					end = Math.min(numberOfLines, end);
 
-				var start = +range[0];
-				var end = +range[1] || start;
-				end = Math.min(numberOfLines, end);
+					if (end < start) return;
 
-				if (end < start) return ;
+					/** @type {HTMLElement} */
+					var line =
+						pre.querySelector(
+							'.line-highlight[data-range="' + currentRange + '"]'
+						) || document.createElement("div");
 
-				/** @type {HTMLElement} */
-				var line = pre.querySelector('.line-highlight[data-range="' + currentRange + '"]') || document.createElement('div');
-
-				mutateActions.push(function () {
-					line.setAttribute('aria-hidden', 'true');
-					line.setAttribute('data-range', currentRange);
-					line.className = (classes || '') + ' line-highlight';
-				});
-
-				// if the line-numbers plugin is enabled, then there is no reason for this plugin to display the line numbers
-				if (hasLineNumbers && Prism.plugins.lineNumbers) {
-					var startNode = Prism.plugins.lineNumbers.getLine(pre, start);
-					var endNode = Prism.plugins.lineNumbers.getLine(pre, end);
-
-					if (startNode) {
-						var top = startNode.offsetTop + codePreOffset + 'px';
-						mutateActions.push(function () {
-							line.style.top = top;
-						});
-					}
-
-					if (endNode) {
-						var height = (endNode.offsetTop - startNode.offsetTop) + endNode.offsetHeight + 'px';
-						mutateActions.push(function () {
-							line.style.height = height;
-						});
-					}
-					
-				} else {
 					mutateActions.push(function () {
-						line.setAttribute('data-start', String(start));
+						line.setAttribute("aria-hidden", "true");
+						line.setAttribute("data-range", currentRange);
+						line.className =
+							(classes || "") +
+							" line-highlight " +
+							generateClassByType(highlighType?.[index]);
+					});
 
-						if (end > start) {
-							line.setAttribute('data-end', String(end));
+					// if the line-numbers plugin is enabled, then there is no reason for this plugin to display the line numbers
+					if (hasLineNumbers && Prism.plugins.lineNumbers) {
+						var startNode = Prism.plugins.lineNumbers.getLine(
+							pre,
+							start
+						);
+						var endNode = Prism.plugins.lineNumbers.getLine(
+							pre,
+							end
+						);
+
+						if (startNode) {
+							var top =
+								startNode.offsetTop + codePreOffset + "px";
+							mutateActions.push(function () {
+								line.style.top = top;
+							});
 						}
 
-						line.style.top = (start - offset - 1) * lineHeight + codePreOffset + 'px';
+						if (endNode) {
+							var height =
+								endNode.offsetTop -
+								startNode.offsetTop +
+								endNode.offsetHeight +
+								"px";
+							mutateActions.push(function () {
+								line.style.height = height;
+							});
+						}
+					} else {
+						mutateActions.push(function () {
+							line.setAttribute("data-start", String(start));
 
-						line.textContent = new Array(end - start + 2).join(' \n');
+							if (end > start) {
+								line.setAttribute("data-end", String(end));
+							}
+
+							line.style.top =
+								(start - offset - 1) * lineHeight +
+								codePreOffset +
+								"px";
+
+							line.textContent = new Array(end - start + 2).join(
+								" \n"
+							);
+						});
+					}
+
+					mutateActions.push(function () {
+						line.style.width = pre.scrollWidth + "px";
 					});
-				}
 
-				mutateActions.push(function () {
-					line.style.width = pre.scrollWidth + 'px';
+					mutateActions.push(function () {
+						// allow this to play nicely with the line-numbers plugin
+						// need to attack to pre as when line-numbers is enabled, the code tag is relatively which screws up the positioning
+						parentElement.appendChild(line);
+					});
 				});
-
-				mutateActions.push(function () {
-					// allow this to play nicely with the line-numbers plugin
-					// need to attack to pre as when line-numbers is enabled, the code tag is relatively which screws up the positioning
-					parentElement.appendChild(line);
-				});
-			});
 
 			var id = pre.id;
-			if (hasLineNumbers && Prism.util.isActive(pre, LINKABLE_LINE_NUMBERS_CLASS) && id) {
+			if (
+				hasLineNumbers &&
+				Prism.util.isActive(pre, LINKABLE_LINE_NUMBERS_CLASS) &&
+				id
+			) {
 				// This implements linkable line numbers. Linkable line numbers use Line Highlight to create a link to a
 				// specific line. For this to work, the pre element has to:
 				//  1) have line numbers,
@@ -229,13 +298,16 @@ export function extendLineHighlightPlugin (Prism) {
 					});
 				}
 
-				var start = parseInt(pre.getAttribute('data-start') || '1');
+				var start = parseInt(pre.getAttribute("data-start") || "1");
 
 				// iterate all line number spans
-				$$('.line-numbers-rows > span', pre).forEach(function (lineSpan, i) {
+				$$(".line-numbers-rows > span", pre).forEach(function (
+					lineSpan,
+					i
+				) {
 					var lineNumber = i + start;
 					lineSpan.onclick = function () {
-						var hash = id + '.' + lineNumber;
+						var hash = id + "." + lineNumber;
 
 						// this will prevent scrolling since the span is obviously in view
 						scrollIntoView = false;
@@ -250,46 +322,51 @@ export function extendLineHighlightPlugin (Prism) {
 			return function () {
 				mutateActions.forEach(callFunction);
 			};
-		}
+		},
 	};
-
 
 	function applyHash() {
 		var hash = location.hash.slice(1);
 
 		// Remove pre-existing temporary lines
-		$$('.temporary.line-highlight').forEach(function (line) {
+		$$(".temporary.line-highlight").forEach(function (line) {
 			line.parentNode.removeChild(line);
 		});
 
-		var range = (hash.match(/\.([\d,-]+)$/) || [, ''])[1];
+		var range = (hash.match(/\.([\d,-]+)$/) || [, ""])[1];
 
 		if (!range || document.getElementById(hash)) {
 			return;
 		}
 
-		var id = hash.slice(0, hash.lastIndexOf('.'));
+		var id = hash.slice(0, hash.lastIndexOf("."));
 		var pre = document.getElementById(id);
 
 		if (!pre) {
 			return;
 		}
 
-		if (!pre.hasAttribute('data-line')) {
-			pre.setAttribute('data-line', '');
+		if (!pre.hasAttribute("data-line")) {
+			pre.setAttribute("data-line", "");
 		}
 
-		var mutateDom = Prism.plugins.lineHighlight.highlightLines(pre, range, 'temporary ');
+		var mutateDom = Prism.plugins.lineHighlight.highlightLines(
+			pre,
+			range,
+			"temporary "
+		);
 		mutateDom();
 
 		if (scrollIntoView) {
-			document.querySelector('.temporary.line-highlight').scrollIntoView();
+			document
+				.querySelector(".temporary.line-highlight")
+				.scrollIntoView();
 		}
 	}
 
 	var fakeTimer = 0; // Hack to limit the number of times applyHash() runs
 
-	Prism.hooks.add('before-sanity-check', function (env) {
+	Prism.hooks.add("before-sanity-check", function (env) {
 		var pre = env.element.parentElement;
 		if (!isActiveFor(pre)) {
 			return;
@@ -303,7 +380,7 @@ export function extendLineHighlightPlugin (Prism) {
 		 * tags change the content of the <code> tag.
 		 */
 		var num = 0;
-		$$('.line-highlight', pre).forEach(function (line) {
+		$$(".line-highlight", pre).forEach(function (line) {
 			num += line.textContent.length;
 			line.parentNode.removeChild(line);
 		});
@@ -313,7 +390,7 @@ export function extendLineHighlightPlugin (Prism) {
 		}
 	});
 
-	Prism.hooks.add('complete', function completeHook(env) {
+	Prism.hooks.add("complete", function completeHook(env) {
 		var pre = env.element.parentElement;
 		if (!isActiveFor(pre)) {
 			return;
@@ -324,8 +401,12 @@ export function extendLineHighlightPlugin (Prism) {
 		var hasLineNumbers = Prism.plugins.lineNumbers;
 		var isLineNumbersLoaded = env.plugins && env.plugins.lineNumbers;
 
-		if (hasClass(pre, LINE_NUMBERS_CLASS) && hasLineNumbers && !isLineNumbersLoaded) {
-			Prism.hooks.add('line-numbers', completeHook);
+		if (
+			hasClass(pre, LINE_NUMBERS_CLASS) &&
+			hasLineNumbers &&
+			!isLineNumbersLoaded
+		) {
+			Prism.hooks.add("line-numbers", completeHook);
 		} else {
 			var mutateDom = Prism.plugins.lineHighlight.highlightLines(pre);
 			mutateDom();
@@ -333,7 +414,7 @@ export function extendLineHighlightPlugin (Prism) {
 		}
 	});
 
-	window.addEventListener('hashchange', applyHash);
+	window.addEventListener("hashchange", applyHash);
 	// window.addEventListener('resize', function () {
 	// 	var actions = $$('pre')
 	// 		.filter(isActiveFor)
@@ -342,5 +423,4 @@ export function extendLineHighlightPlugin (Prism) {
 	// 		});
 	// 	actions.forEach(callFunction);
 	// });
-
 }

--- a/src/CM6Extensions.ts
+++ b/src/CM6Extensions.ts
@@ -7,130 +7,198 @@ import { syntaxTree, lineClassNodeProp } from '@codemirror/language'
 import { braceSurroundingRegex, paramRegex } from './util'
 
 interface CodeblockInfo {
-  showLineNumbers: boolean;
-  highlightLines: number[] | null;
+	showLineNumbers: boolean;
+	highlightLines: number[] | null;
+	typeLines: string[] | null;
 }
 
 class LineNumberWidget extends WidgetType {
-  idx: number;
+	idx: number;
 
-  constructor(idx: number) {
-    super();
+	constructor(idx: number) {
+		super();
     this.idx = idx
-  }
+	}
 
-  toDOM() {
+	toDOM() {
     const el = document.createElement('span');
     el.className = 'live-preview-codeblock-line-nums';
     el.textContent = '' + this.idx;
-    return el;
-  }
+		return el;
+	}
 }
 
-export const livePreviewCM6Extension = ViewPlugin.fromClass(class {
-  decorations: DecorationSet
+function generateClassByType(type: string) {
+	switch (type) {
+		case "a":
+			return "live-preview-codeblock-highlight add-live-preview-codeblock-highlight";
+		case "e":
+			return "live-preview-codeblock-highlight error-live-preview-codeblock-highlight";
+		case "c":
+			return "live-preview-codeblock-highlight comment-live-preview-codeblock-highlight";
+		case "g":
+			return "live-preview-codeblock-highlight general-live-preview-codeblock-highlight";
+		default:
+			return "live-preview-codeblock-highlight general-live-preview-codeblock-highlight";
+	}
+}
 
-  constructor(view: EditorView) {
-    this.decorations = this.buildDecorations(view);
-  }
+export const livePreviewCM6Extension = ViewPlugin.fromClass(
+	class {
+		decorations: DecorationSet;
 
-  update(update: ViewUpdate) {
-    if (update.docChanged || update.viewportChanged) this.decorations = this.buildDecorations(update.view);
-  }
+		constructor(view: EditorView) {
+			this.decorations = this.buildDecorations(view);
+		}
 
-  destory() {}
+		update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged) this.decorations = this.buildDecorations(update.view);
+		}
 
-  buildDecorations(view: EditorView) {
-    const builder = new RangeSetBuilder<Decoration>();
-    const codeblockInfo: CodeblockInfo = {
-      showLineNumbers: false,
-      highlightLines: null,
-    }
-    let startLineNum: number;
+		destory() {}
+
+		buildDecorations(view: EditorView) {
+			const builder = new RangeSetBuilder<Decoration>();
+			const codeblockInfo: CodeblockInfo = {
+				showLineNumbers: false,
+				highlightLines: null,
+				typeLines: null,
+			};
+			let startLineNum: number;
 
     for (const {from, to} of view.visibleRanges) {
-      try {
+			try {
         const tree = syntaxTree(view.state)
 
-        tree.iterate({
-          from, to,
-          // @ts-ignore
-          enter: ({type, from, to}) => {
+					tree.iterate({
+            from, to,
+						// @ts-ignore
+            enter: ({type, from, to}) => {
             const lineClasses = type.prop(lineClassNodeProp)
 
             if (!lineClasses) return ;
             const classes = new Set(lineClasses.split(' '));
             const isCodeblockBegin = classes.has('HyperMD-codeblock-begin');
-            const isCodeblockLine = 
+							const isCodeblockLine =
               classes.has('HyperMD-codeblock-bg') 
               && !classes.has('HyperMD-codeblock-begin')
               && !classes.has('HyperMD-codeblock-end');
 
-            // reset data when found codeblock begin line.
-            if (isCodeblockBegin) {
-              const startLine = view.state.doc.lineAt(from);
+							// reset data when found codeblock begin line.
+							if (isCodeblockBegin) {
+								const startLine = view.state.doc.lineAt(from);
               const codeblockParams = startLine.text.match(paramRegex).slice(1);
               const highlightParam = codeblockParams.find((param) => braceSurroundingRegex.test(param))?.slice(1, -1);
 
-              startLineNum = startLine.number;
-              codeblockInfo.showLineNumbers = false;
-              codeblockInfo.highlightLines = null;
+								startLineNum = startLine.number;
+								codeblockInfo.showLineNumbers = false;
+								codeblockInfo.highlightLines = null;
 
-              if (codeblockParams.includes('nums')) codeblockInfo.showLineNumbers = true;
-              if (highlightParam) codeblockInfo.highlightLines = highlightParam.replace(' ', '').split(',').flatMap((line) => {
-                if (!+line) {
-                  const res = [];
-                  const [start, end] = line.split('-');
-                  for (let i = +start; i <= +end; i++) {
-                    res.push(i);
-                  }
+								if (codeblockParams.includes("nums"))
+									codeblockInfo.showLineNumbers = true;
+								if (highlightParam) {
+									const [_highlightLines, _typeLines] =
+										highlightParam
+											.replace(" ", "")
+											.split(",")
+											.reduce(
+												(
+													acc: [number[],string[]],
+													line: string
+												) => {
+													const type2 =
+														line.split("@")[0] ||
+														"g";
+													const _line = line.split(
+														"@"
+													)[1]
+														? line.split("@")[1]
+														: line.split("@")[0];
+													if (!+_line) {
+														const res = [];
+														const _type = [];
+														const [start, end] =
+															_line.split("-");
+														for (
+															let i = +start;
+															i <= +end;
+															i++
+														) {
+															res.push(i);
+															_type.push(type2);
+														}
 
-                  return res;
-                }
+														acc[0].push(...res);
+														acc[1].push(..._type);
+														return acc;
+													}
+													acc[0].push(+_line);
+													acc[1].push(type2);
+													return acc;
+												},
+												[[], []]
+											);
+									codeblockInfo.highlightLines =
+										_highlightLines;
+									codeblockInfo.typeLines = _typeLines;
+								}
+							}
 
-                return [+line];
-              });
+              if (!isCodeblockLine) return ;
+
+              const currentLineNum = view.state.doc.lineAt(from).number;
+
+							if (codeblockInfo.showLineNumbers) {
+								const deco = Decoration.widget({
+                  widget: new LineNumberWidget(currentLineNum - startLineNum),
+                  side: -10000
+								});
+								builder.add(from, from, deco);
+							}
+
+							if (codeblockInfo.highlightLines) {
+								if (
+									codeblockInfo.highlightLines.includes(
+										currentLineNum - startLineNum
+									)
+								) {
+									const highlightIndex =
+										codeblockInfo.highlightLines.findIndex(
+											(line) =>
+												line ===
+												currentLineNum - startLineNum
+										);
+									const line = view.state.doc.lineAt(from);
+									const deco = Decoration.line({
+										attributes: {
+											class: generateClassByType(
+												codeblockInfo.typeLines[
+													highlightIndex
+												]
+											),
+										},
+									});
+
+									// @ts-ignore
+									if (builder.last?.startSide) {
+										// @ts-ignore
+										deco.startSide = builder.last.startSide;
+                    deco.endSide = deco.startSide
+									}
+
+									builder.add(line.from, line.from, deco);
+								}
+							}
             }
+          })
+				} catch (error) {
+          console.log(error)
+				}
+			}
 
-            if (!isCodeblockLine) return ;
-            
-            const currentLineNum = view.state.doc.lineAt(from).number;
-
-            if (codeblockInfo.showLineNumbers) {
-              const deco = Decoration.widget({
-                widget: new LineNumberWidget(currentLineNum - startLineNum),
-                side: -10000
-              });
-              builder.add(from, from, deco);
-            }
-
-            if (codeblockInfo.highlightLines) {
-              if (codeblockInfo.highlightLines.includes(currentLineNum - startLineNum)) {
-                const line = view.state.doc.lineAt(from);
-                const deco = Decoration.line({
-                  attributes: {class: 'live-preview-codeblock-highlight'}
-                })
-
-                // @ts-ignore
-                if (builder.last?.startSide) {
-                  // @ts-ignore
-                  deco.startSide = builder.last.startSide;
-                  deco.endSide = deco.startSide
-                }
-
-                builder.add(line.from, line.from, deco);
-              }
-            }
-          }
-        })
-      } catch (error) {
-        console.log(error)
-      }
-    }
-
-    return builder.finish();
-  }
-}, 
-{
-  decorations: v => v.decorations
+			return builder.finish();
+		}
+	},
+	{
+    decorations: v => v.decorations
 })

--- a/src/CM6Extensions.ts
+++ b/src/CM6Extensions.ts
@@ -1,10 +1,17 @@
-import { ViewPlugin, ViewUpdate, EditorView, DecorationSet, Decoration, WidgetType } from '@codemirror/view'
+import {
+	ViewPlugin,
+	ViewUpdate,
+	EditorView,
+	DecorationSet,
+	Decoration,
+	WidgetType,
+} from "@codemirror/view";
 // @ts-ignore
-import { RangeSetBuilder } from '@codemirror/state'
+import { RangeSetBuilder } from "@codemirror/state";
 // @ts-ignore
-import { syntaxTree, lineClassNodeProp } from '@codemirror/language'
+import { syntaxTree, lineClassNodeProp } from "@codemirror/language";
 // import { lineClassNodeProp } from '@codemirror/stream-parser'
-import { braceSurroundingRegex, paramRegex } from './util'
+import { braceSurroundingRegex, paramRegex } from "./util";
 
 interface CodeblockInfo {
 	showLineNumbers: boolean;
@@ -17,13 +24,13 @@ class LineNumberWidget extends WidgetType {
 
 	constructor(idx: number) {
 		super();
-    this.idx = idx
+		this.idx = idx;
 	}
 
 	toDOM() {
-    const el = document.createElement('span');
-    el.className = 'live-preview-codeblock-line-nums';
-    el.textContent = '' + this.idx;
+		const el = document.createElement("span");
+		el.className = "live-preview-codeblock-line-nums";
+		el.textContent = "" + this.idx;
 		return el;
 	}
 }
@@ -52,7 +59,8 @@ export const livePreviewCM6Extension = ViewPlugin.fromClass(
 		}
 
 		update(update: ViewUpdate) {
-      if (update.docChanged || update.viewportChanged) this.decorations = this.buildDecorations(update.view);
+			if (update.docChanged || update.viewportChanged)
+				this.decorations = this.buildDecorations(update.view);
 		}
 
 		destory() {}
@@ -66,29 +74,42 @@ export const livePreviewCM6Extension = ViewPlugin.fromClass(
 			};
 			let startLineNum: number;
 
-    for (const {from, to} of view.visibleRanges) {
-			try {
-        const tree = syntaxTree(view.state)
+			for (const { from, to } of view.visibleRanges) {
+				try {
+					const tree = syntaxTree(view.state);
 
 					tree.iterate({
-            from, to,
+						from,
+						to,
 						// @ts-ignore
-            enter: ({type, from, to}) => {
-            const lineClasses = type.prop(lineClassNodeProp)
+						enter: ({ type, from, to }) => {
+							const lineClasses: any =
+								type.prop(lineClassNodeProp);
 
-            if (!lineClasses) return ;
-            const classes = new Set(lineClasses.split(' '));
-            const isCodeblockBegin = classes.has('HyperMD-codeblock-begin');
+							if (!lineClasses) return;
+							const classes = lineClasses
+								? new Set(lineClasses?.split(" "))
+								: null;
+							const isCodeblockBegin = classes.has(
+								"HyperMD-codeblock-begin"
+							);
 							const isCodeblockLine =
-              classes.has('HyperMD-codeblock-bg') 
-              && !classes.has('HyperMD-codeblock-begin')
-              && !classes.has('HyperMD-codeblock-end');
+								classes &&
+								classes.has("HyperMD-codeblock-bg") &&
+								!classes.has("HyperMD-codeblock-begin") &&
+								!classes.has("HyperMD-codeblock-end");
 
 							// reset data when found codeblock begin line.
 							if (isCodeblockBegin) {
 								const startLine = view.state.doc.lineAt(from);
-              const codeblockParams = startLine.text.match(paramRegex).slice(1);
-              const highlightParam = codeblockParams.find((param) => braceSurroundingRegex.test(param))?.slice(1, -1);
+								const codeblockParams = startLine.text
+									.match(paramRegex)
+									.slice(1);
+								const highlightParam = codeblockParams
+									.find((param) =>
+										braceSurroundingRegex.test(param)
+									)
+									?.slice(1, -1);
 
 								startLineNum = startLine.number;
 								codeblockInfo.showLineNumbers = false;
@@ -103,7 +124,7 @@ export const livePreviewCM6Extension = ViewPlugin.fromClass(
 											.split(",")
 											.reduce(
 												(
-													acc: [number[],string[]],
+													acc: [number[], string[]],
 													line: string
 												) => {
 													const type2 =
@@ -144,14 +165,17 @@ export const livePreviewCM6Extension = ViewPlugin.fromClass(
 								}
 							}
 
-              if (!isCodeblockLine) return ;
+							if (!isCodeblockLine) return;
 
-              const currentLineNum = view.state.doc.lineAt(from).number;
+							const currentLineNum =
+								view.state.doc.lineAt(from).number;
 
 							if (codeblockInfo.showLineNumbers) {
 								const deco = Decoration.widget({
-                  widget: new LineNumberWidget(currentLineNum - startLineNum),
-                  side: -10000
+									widget: new LineNumberWidget(
+										currentLineNum - startLineNum
+									),
+									side: -10000,
 								});
 								builder.add(from, from, deco);
 							}
@@ -183,16 +207,16 @@ export const livePreviewCM6Extension = ViewPlugin.fromClass(
 									if (builder.last?.startSide) {
 										// @ts-ignore
 										deco.startSide = builder.last.startSide;
-                    deco.endSide = deco.startSide
+										deco.endSide = deco.startSide;
 									}
 
 									builder.add(line.from, line.from, deco);
 								}
 							}
-            }
-          })
+						},
+					});
 				} catch (error) {
-          console.log(error)
+					console.log(error);
 				}
 			}
 
@@ -200,5 +224,6 @@ export const livePreviewCM6Extension = ViewPlugin.fromClass(
 		}
 	},
 	{
-    decorations: v => v.decorations
-})
+		decorations: (v) => v.decorations,
+	}
+);

--- a/src/postProcessor.ts
+++ b/src/postProcessor.ts
@@ -66,7 +66,7 @@ function onMounted(element: HTMLElement, onAttachCallback: () => void) {
 function handleLineNumbers(
 	pre: HTMLPreElement,
 	params: string[],
-	initHandlers: HandlerSet,
+	initHandlers: HandlerSet
 ) {
 	if (!params.includes("nums")) return;
 
@@ -74,7 +74,7 @@ function handleLineNumbers(
 
 	const initLineNumbers = () => {
 		window.Prism.plugins.lineNumbers.resize(pre);
-	}
+	};
 
 	initHandlers.push(initLineNumbers);
 }
@@ -82,18 +82,18 @@ function handleLineNumbers(
 function handleLineHighlight(
 	pre: HTMLPreElement,
 	params: string[],
-	initHandlers: HandlerSet,
+	initHandlers: HandlerSet
 ) {
 	const lineHightlightParamIdx = params.findIndex((param) =>
 		braceSurroundingRegex.test(param)
 	);
-	if (lineHightlightParamIdx === -1) return ;
+	if (lineHightlightParamIdx === -1) return;
 
 	pre.dataset.line = params[lineHightlightParamIdx].slice(1, -1);
 
 	const initLineHighlight = () => {
 		window.Prism.plugins.lineHighlight.highlightLines(pre)();
-	}
+	};
 
 	initHandlers.push(initLineHighlight);
 }
@@ -125,9 +125,11 @@ export function commonCodeblockPostProcessor(
 	});
 
 	// Reinit after resize
-	plugin.registerEvent(app.workspace.on('resize', () => {
-		initHandlers.forEach((handler) => {
-			handler();
+	plugin.registerEvent(
+		app.workspace.on("resize", () => {
+			initHandlers.forEach((handler) => {
+				handler();
+			});
 		})
-	}))
+	);
 }

--- a/styles.css
+++ b/styles.css
@@ -143,5 +143,21 @@ pre[id].linkable-line-numbers span.line-numbers-rows > span:hover:before {
 		to right,
 		hsla(24, 20%, 50%, 0.1) 70%,
 		hsla(24, 20%, 50%, 0)
-	);	
+	);
+}
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
+	background-color: #1d572d;
+}
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
+	background-color: #301a1f;
+}
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
+	background: var(--background-code);
+}
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.comment-live-preview-codeblock-highlight
+	> .cm-hmd-codeblock {
+	color: #b97dc9 !important;
+}
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
+	background-color: #393d1b;
 }

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@ pre[class*="language-"].line-numbers {
 	white-space: pre-wrap;
 }
 
-pre[class*="language-"].line-numbers > code {
+pre[class*="language-"].line-numbers>code {
 	position: relative;
 	white-space: inherit;
 }
@@ -21,7 +21,9 @@ pre[class*="language-"].line-numbers > code {
 	top: 0;
 	font-size: 100%;
 	left: -3.8em;
-	width: 3em; /* works for line-numbers below 1000 lines */
+	/* works for line-numbers below 1000 lines */
+	width: 3em;
+
 	letter-spacing: -1px;
 	border-right: 1px solid #999;
 
@@ -31,12 +33,12 @@ pre[class*="language-"].line-numbers > code {
 	user-select: none;
 }
 
-.line-numbers-rows > span {
+.line-numbers-rows>span {
 	display: block;
 	counter-increment: linenumber;
 }
 
-.line-numbers-rows > span:before {
+.line-numbers-rows>span:before {
 	content: counter(linenumber);
 	color: #999;
 	display: block;
@@ -68,14 +70,14 @@ pre[data-line] {
 	left: 0;
 	right: 0;
 	padding: inherit 0;
-	margin-top: 1em; /* Same as .prism’s padding-top */
+
+	/* Same as .prism’s padding-top */
+	margin-top: 1em;
 
 	background: hsla(24, 20%, 50%, 0.08);
-	background: linear-gradient(
-		to right,
-		hsla(24, 20%, 50%, 0.1) 70%,
-		hsla(24, 20%, 50%, 0)
-	);
+	background: linear-gradient(to right,
+			hsla(24, 20%, 50%, 0.1) 70%,
+			hsla(24, 20%, 50%, 0));
 
 	pointer-events: none;
 
@@ -130,34 +132,59 @@ code .line-highlight {
 pre[id].linkable-line-numbers span.line-numbers-rows {
 	pointer-events: all;
 }
-pre[id].linkable-line-numbers span.line-numbers-rows > span:before {
+
+pre[id].linkable-line-numbers span.line-numbers-rows>span:before {
 	cursor: pointer;
 }
-pre[id].linkable-line-numbers span.line-numbers-rows > span:hover:before {
+
+pre[id].linkable-line-numbers span.line-numbers-rows>span:hover:before {
 	background-color: rgba(128, 128, 128, 0.2);
 }
 
 .HyperMD-codeblock-bg.live-preview-codeblock-highlight {
 	background: hsla(24, 20%, 50%, 0.08);
-	background: linear-gradient(
-		to right,
-		hsla(24, 20%, 50%, 0.1) 70%,
-		hsla(24, 20%, 50%, 0)
-	);
+	background: linear-gradient(to right,
+			hsla(24, 20%, 50%, 0.1) 70%,
+			hsla(24, 20%, 50%, 0));
 }
+
 .HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
 	background-color: #1d572d;
 }
-.HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
+
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.error-live-preview-codeblock-highlight {
 	background-color: #301a1f;
 }
-.HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
+
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.general-live-preview-codeblock-highlight {
 	background: var(--background-code);
 }
-.HyperMD-codeblock-bg.live-preview-codeblock-highlight.comment-live-preview-codeblock-highlight
-	> .cm-hmd-codeblock {
+
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.comment-live-preview-codeblock-highlight>.cm-hmd-codeblock {
 	color: #b97dc9 !important;
 }
-.HyperMD-codeblock-bg.live-preview-codeblock-highlight.add-live-preview-codeblock-highlight {
+
+.HyperMD-codeblock-bg.live-preview-codeblock-highlight.general-live-preview-codeblock-highlight {
+	background-color: #393d1b;
+}
+
+/* //= render highlight in reading mode */
+.line-highlight.add-reading-codeblock-highlight {
+	background-color: #1d572d;
+}
+
+.line-highlight.error-reading-codeblock-highlight {
+	background-color: #301a1f;
+}
+
+.line-highlight.general-reading-codeblock-highlight {
+	background: var(--background-code);
+}
+
+.line-highlight.comment-reading-codeblock-highlight>.cm-hmd-codeblock {
+	color: #b97dc9 !important;
+}
+
+.line-highlight.general-reading-codeblock-highlight {
 	background-color: #393d1b;
 }


### PR DESCRIPTION
now you can use multiple colors for your use cases like "add", "error", "comment"...
### Usage:
```bash
{types}@{lines}

// examples:
a@1
e@3-5
```
- types: one of those but not required
  - "a": add
  - "e": error
  - "c": comment
  - "g": general (default)
- "@" : delimiter
- lines: number of lines

![image](https://user-images.githubusercontent.com/61213745/227791190-e4e2532a-d02a-42c7-8fc1-f345ac5f3527.png)


### Classes:
I add those classes by default but you can custom theme:
- `add-live-preview-codeblock-highlight`
- `error-live-preview-codeblock-highlight`
- `comment-live-preview-codeblock-highlight`
- `general-live-preview-codeblock-highlight`